### PR TITLE
SharedList 迭代器小优化

### DIFF
--- a/Pinecones/Pinecone/src/main/java/com/pinecone/framework/unit/SharedList.java
+++ b/Pinecones/Pinecone/src/main/java/com/pinecone/framework/unit/SharedList.java
@@ -286,6 +286,7 @@ public class SharedList<T> extends AbstractList<T> implements List<T>, Serializa
     private Iterator<T> skipIterator(int skipNum){
         return new Itr(skipNum);
     }
+
     private class Itr implements Iterator<T> {
 
         private int cursor;
@@ -297,6 +298,8 @@ public class SharedList<T> extends AbstractList<T> implements List<T>, Serializa
         private Iterator<T> selfItr = null;
 
         private boolean selfFlag = false;
+
+        private final boolean selfElementIsShared = elementData instanceof SharedList;
 
         private int lastCursor = -1;
 
@@ -321,11 +324,14 @@ public class SharedList<T> extends AbstractList<T> implements List<T>, Serializa
         public T next() {
             int i = cursor++;
 
-            indexOutOfSizeThrow(i);
+            if(currentSharedItr!=null && currentSharedItr.hasNext()){
+                return currentSharedItr.next();
+            }
+
             for(;;){
-                if(sharedLists.isEmpty() || selfFlag){
+                if(selfFlag || sharedLists.isEmpty()){
                     int ptr = invokeIndex(i, selfSizeIndex());
-                    if(elementData instanceof SharedList){
+                    if(selfElementIsShared){
                         if(selfItr == null) {
                             selfItr = ((SharedList<T>) elementData).skipIterator(ptr);
                         }
@@ -335,14 +341,12 @@ public class SharedList<T> extends AbstractList<T> implements List<T>, Serializa
                     }
                 }
 
-                if(nowSharedListIndex == -1 || Objects.isNull(currentSharedItr) || !currentSharedItr.hasNext()){
-                    nowSharedListIndex++;
-                    if(nowSharedListIndex>=sharedLists.size()){
-                        selfFlag = true;
-                        continue;
-                    }
-                    currentSharedItr = sharedLists.get(nowSharedListIndex).skipIterator(invokeIndex(i, nowSharedListIndex));
+                nowSharedListIndex++;
+                if(nowSharedListIndex>=sharedLists.size()){
+                    selfFlag = true;
+                    continue;
                 }
+                currentSharedItr = sharedLists.get(nowSharedListIndex).skipIterator(invokeIndex(i, nowSharedListIndex));
 
                 return currentSharedItr.next();
             }

--- a/Pinecones/Pinecone/src/main/java/com/pinecone/framework/unit/SharedList.java
+++ b/Pinecones/Pinecone/src/main/java/com/pinecone/framework/unit/SharedList.java
@@ -365,6 +365,20 @@ public class SharedList<T> extends AbstractList<T> implements List<T>, Serializa
     }
 
     @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("[");
+        for (T t : this) {
+            sb.append(t).append(",");
+        }
+        sb.deleteCharAt(sb.length()-1);
+        sb.append("]");
+
+        return sb.toString();
+    }
+
+    @Override
     public boolean containsKey( Object elm ) {
         try {
             if( elm instanceof Number ) {
@@ -375,7 +389,7 @@ public class SharedList<T> extends AbstractList<T> implements List<T>, Serializa
                 }
                 return nLength > nElm;
             }
-            return this.containsKey( (int)Integer.valueOf(elm.toString()) );
+            return this.containsKey( Integer.parseInt(elm.toString()) );
         }
         catch ( NumberFormatException e ){
             return false;


### PR DESCRIPTION
将一些高重复判断至前，避免每次同数组迭代器使用遍历，都需要进行自身判断
![6{~UMAE}T{J(KRZYUGQN7CR](https://github.com/user-attachments/assets/04bac9c2-d905-4e43-86fc-0638f352c10c)
